### PR TITLE
Fix register_on_leaveplayer failure during startup

### DIFF
--- a/mobf_settings/fstk/ui_mod.lua
+++ b/mobf_settings/fstk/ui_mod.lua
@@ -200,4 +200,4 @@ end
 --------------------------------------------------------------------------------
 
 minetest.register_on_player_receive_fields(handle_buttons)
-minetest.register_on_leaveplayer(player)
+minetest.register_on_leaveplayer(player_leave)


### PR DESCRIPTION
This fixed a bug when minetest cannot start with mobf_settings mod enabled.