### PR TITLE
Call 'minetest.global_exists' before calling global 'factions'

### DIFF
--- a/animal_wolf/init.lua
+++ b/animal_wolf/init.lua
@@ -281,7 +281,7 @@ mobf_spawner_register("wolf_spawner_1",wolf_name,
 	collisionbox = selectionbox_wolf
 	})
 
-if factions~= nil and
+if minetest.global_exists("factions") and factions ~= nil and
 	type(factions.set_base_reputation) == "function" then
 	factions.set_base_reputation("wolfs","players",-25)
 end

--- a/mob_ghost/init.lua
+++ b/mob_ghost/init.lua
@@ -212,7 +212,7 @@ mobf_spawner_register("ghost_spawner_1",ghost_name,
 	collisionbox = selectionbox_ghost
 	})
 
-if factions~= nil and
+if minetest.global_exists("factions") and factions ~= nil and
 	type(factions.set_base_reputation) == "function" then
 	factions.set_base_reputation("ghosts","players",-25)
 end

--- a/mob_warthog/init.lua
+++ b/mob_warthog/init.lua
@@ -191,7 +191,7 @@ mobf_spawner_register("warthog_spawner_1",warthog_name,
 	collisionbox = selectionbox_warthog
 	})
 
-if factions~= nil and
+if minetest.global_exists("factions") and factions ~= nil and
 	type(factions.set_base_reputation) == "function" then
 	factions.set_base_reputation("warthogs","players",-5)
 end


### PR DESCRIPTION
Fixes 'Undeclared global variable "factions"'.